### PR TITLE
add route for options to send back a 200 for preflight response

### DIFF
--- a/routes/routes.js
+++ b/routes/routes.js
@@ -180,6 +180,10 @@ async function removeUserFromAllSessions(allSessions, userId) {
     })
 }
 
+router.options('*', corsHeaders, async (req, res) => {
+    res.send(200);
+})
+
 // Create Sessions
 router.post('/api/sessions', getAllUsers, authUser, async (req, res, next) => {
     const { allExistingUsers } = res.locals;


### PR DESCRIPTION
`Access to XMLHttpRequest at 'https://api.gudnus.site/api/users/login/' from origin 'https://www.gudn.us' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.`
```
api.gudnus.site/api/users/login/:1 Failed to load resource: net::ERR_FAILED
```

<img width="790" alt="Screen Shot 2020-10-01 at 7 21 06 AM" src="https://user-images.githubusercontent.com/41380090/94803060-b6c18880-03b6-11eb-87b9-6f8b394cdfdd.png">
